### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       
       - name: Setup Node.js
         uses: actions/setup-node@89d709d423dc495668cd762a18dd4a070611be3f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions: {}
+
 jobs:
   check-ci:
     runs-on: ubuntu-latest
+    permissions:
+      checks: read
     steps:
       - name: Wait for CI to pass
         id: wait-for-ci
@@ -31,13 +35,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@89d709d423dc495668cd762a18dd4a070611be3f
         with:
           node-version-file: 'package.json'
-          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm to latest


### PR DESCRIPTION
## Summary
- Add restrictive `permissions: {}` at workflow level with minimal per-job grants (`contents: read` for CI, `checks: read` for check-ci, `id-token: write` + `contents: read` for release)
- Upgrade `actions/checkout` to v6.0.2 with `persist-credentials: false` in both workflows to prevent credential persistence (artipacked)
- Remove explicit npm cache (`cache: 'npm'`) from release workflow's `setup-node` step to mitigate cache-poisoning on tag-push triggers